### PR TITLE
Fix buildUrl() to exclude URL params from query string

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "angular-resource-sails",
-	"version": "1.1.14",
+	"version": "1.1.15",
 	"main": "./src/sailsResource.js",
 	"contributors": [
 		"Joshua Prodahl <jprodahl@gmail.com> (http://returnnull.com)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-resource-sails",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "private": false,
   "description": "Angular $resource style service for accessing sails socket.io resources",
   "main": "",

--- a/src/sailsResource.js
+++ b/src/sailsResource.js
@@ -531,6 +531,8 @@
      */
     function buildUrl(model, id, action, params, options) {
         var url = [];
+        var urlParams = {};
+        
         if (action && action.url) {
             var actionUrl = action.url;
 
@@ -539,7 +541,12 @@
             if (matches) {
                 forEach(matches, function (match) {
                     var paramName = match.replace(':', '');
-                    actionUrl = actionUrl.replace(match, paramName == 'id' ? id : params[paramName]);
+                    if (paramName === 'id') {
+                        actionUrl = actionUrl.replace(match, id);
+                    } else {
+                        urlParams[paramName] = true;
+                        actionUrl = actionUrl.replace(match, params[paramName]);
+                    }
                 });
             }
 
@@ -551,7 +558,16 @@
             url.push(model + (options.pluralize ? "s" : ""));
             if (id) url.push('/' + id);
         }
-        url.push(createQueryString(params));
+        
+        // Filter out params already used for URL
+        var queryParams = {};
+        angular.forEach(params, function(value, key) {
+            if (!urlParams[key]) {
+                queryParams[key] = value;
+            }
+        });
+        
+        url.push(createQueryString(queryParams));
         return url.join('');
     }
 


### PR DESCRIPTION
``` javascript
var Course = sailsResource("course", {
    findAllByStudent: {
        method: "GET",
        url: "/students/:student/courses"
    }
});

Course.findAllByStudent({student: 42});
```

Currently this call will build URL `/students/42/courses?student=42`. Though should (and will after this PR) build `/students/42/courses`.
